### PR TITLE
Added Script to Extract GST Numbers from Invoices present in Google drive

### DIFF
--- a/scripts/GST- Details extract from invoice pdf/README.md
+++ b/scripts/GST- Details extract from invoice pdf/README.md
@@ -1,0 +1,8 @@
+# This script uses Regular Expression to find the GST numbers present in the Invoice pdf
+
+# dependencies 
+pip install google-colab
+pip install pdfplumber
+pip install pandas
+
+you have to provide the path to your drive folder. Works better on Google Colab

--- a/scripts/GST- Details extract from invoice pdf/gst.py
+++ b/scripts/GST- Details extract from invoice pdf/gst.py
@@ -1,0 +1,22 @@
+import pdfplumber
+import pandas as pd
+from google.colab import drive
+import os
+drive.mount('/content/gdrive')
+os.chdir("/content/gdrive/PATH TO FOLDER CONTAINING INVOICES PDF")
+os.getcwd()
+invoices = os.listdir()
+print(invoices)
+import re
+df = []
+for inv in invoices:
+  gst = pdfplumber.open(inv) #it will open each file in the directory
+  page = gst.pages[0] #selecting the first page
+  text = page.extract_text()
+  gst_no = re.compile(r'\d{2}[A-Z]{5}\d{4}[A-Z]{1}[A-Z\d]{1}[Z]{1}[A-Z\d]{1}')
+  m =gst_no.findall(text)
+  print(m)
+  df = df+[m]
+gstin = pd.DataFrame(df)
+gstin
+gstin.to_csv('gstin.csv', index=False)


### PR DESCRIPTION
## Description

Added Python Script to get the GST number from the invoices pdf Present in your google drive and make a CSV file containing all the GST numbers.  <br />



## Dependencies

pip install google-colab
pip install pandas
pip install pdfplumber



## Developer's checklist

- [ ✅] My PR follows the style guidelines of this project
- [✅ ] I have performed a self-check on my work

